### PR TITLE
update_type missing bug

### DIFF
--- a/drain-service/drain_training_inferencing.py
+++ b/drain-service/drain_training_inferencing.py
@@ -80,6 +80,9 @@ async def train_and_inference(incoming_logs_to_train_queue, fail_keywords_str):
                 }
                 inferencing_results.append(d)
 
+        if not inferencing_results:
+            continue
+
         df = pd.DataFrame(inferencing_results)
 
         update_counts = df["update_type"].value_counts().to_dict()


### PR DESCRIPTION
Addressed because we observed

```
/usr/local/lib/python3.8/site-packages/pandas/core/strings/accessor.py:101: UserWarning: This pattern has match groups. To actually get the groups, use str.extract.
  return func(self, *args, **kwargs)
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 3080, in get_loc
    return self._engine.get_loc(casted_key)
  File "pandas/_libs/index.pyx", line 70, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 101, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 4554, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 4562, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 'update_type'
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "./drain_training_inferencing.py", line 364, in <module>
    loop.run_until_complete(
  File "/usr/local/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "./drain_training_inferencing.py", line 89, in train_and_inference
    update_counts = df["update_type"].value_counts().to_dict()
  File "/usr/local/lib/python3.8/site-packages/pandas/core/frame.py", line 3024, in __getitem__
    indexer = self.columns.get_loc(key)
  File "/usr/local/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 3082, in get_loc
    raise KeyError(key) from err
KeyError: 'update_type'
```