### PR TITLE
Await queue put operation

### DIFF
--- a/drain-service/drain_training_inferencing.py
+++ b/drain-service/drain_training_inferencing.py
@@ -212,7 +212,7 @@ async def update_es_logs(queue):
                     "Failed to index data. Re-adding to logs_to_update_in_elasticsearch queue"
                 )
                 logging.error(exception)
-                queue.put(anomaly_df)
+                await queue.put(anomaly_df)
             except TransportError as exception:
                 logging.info(f"Error in async_streaming_bulk {exception}")
                 if exception.status_code == "N/A":


### PR DESCRIPTION
Addresses this warning observed:

```
./drain_training_inferencing.py:207: RuntimeWarning: coroutine 'Queue.put' was never awaited
  queue.put(anomaly_df)
```