### PR TITLE
Address bug in match function within TemplateMiner class

### DIFF
--- a/drain-service/drain3/template_miner.py
+++ b/drain-service/drain3/template_miner.py
@@ -156,7 +156,7 @@ class TemplateMiner:
         :param log_message: log message to match
         :return: Matched cluster or None of no match found.
         """
-        matched_cluster = self.drain.match(masked_content)
+        matched_cluster = self.drain.match(log_message)
         return matched_cluster
 
     def get_parameter_list(self, log_template: str, content: str):


### PR DESCRIPTION
Within the TemplateMiner class, the match function was not using the log_message variable that was being passed in. This has been addressed in this pull request. 